### PR TITLE
Add configuration schema

### DIFF
--- a/cybele/config.json
+++ b/cybele/config.json
@@ -1,29 +1,44 @@
 {
   "name": "Cybele",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "slug": "cybele",
   "description": "BLE to MQTT Gateway for Smarthome and IoT Devices",
   "url": "https://github.com/ArtistAOP/hassio/tree/main/cybele",
   "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
   "startup": "application",
   "boot": "auto",
-
   "host_dbus": true,
-  
-  "options":
-	{
-	  "mqtt": {
-		"url": "mqtt://my_user:my_password@core-mosquitto"
-	  },
-	  "dongles": [
-		{
-		  "hciDevice": "hci0",
-		  "mode": "le",
-		  "services": [],
-		  "devices": [
-		  ]
-		}
-	  ]
-	},
-  "schema": false
+  "options": {
+    "mqtt": {
+      "url": "mqtt://my_user:my_password@core-mosquitto"
+    },
+    "dongles": [
+      {
+        "hciDevice": "hci0",
+        "mode": "le",
+        "services": [],
+        "devices": [
+          { 
+            "type": "MiKettleDevice2",
+            "friendlyName": "Mi Kettle2",
+            "mac": "B8:7C:6F:7C:0A:31",
+            "productId": 275
+          }
+        ]
+      }
+    ]
+  },
+  "schema": {
+    "mqtt": {
+      "url": "url"
+    },
+    "dongles": [
+      {
+        "hciDevice": "str",
+        "mode": "str",
+        "services": [],
+        "devices": []
+      }
+    ]
+  }
 }


### PR DESCRIPTION
I'm still working on it. There is validation problem with nested here.
Same as here: https://github.com/home-assistant/supervisor/issues/2560

Just tried add configuration schema to avoid following error.

![image](https://user-images.githubusercontent.com/2917861/108123245-d6c3c100-70a5-11eb-9c15-bb41f9bb8306.png)
Also mentioned here: https://community.home-assistant.io/t/xiaomi-kettle/34170/21

I've tried to add complete schema:
```
"schema": {
    "mqtt": {
      "url": "url"
    },
    "dongles": [
      {
        "hciDevice": "str",
        "mode": "str",
        "services": [
          {
            "bus": "str?",
            "hciDevice": "str?"
          }
        ],
        "devices": [
          {
            "type": "str",
            "friendlyName": "str",
            "mac": "match(^([0-9A-F]{2}:){5}([0-9A-F]{2})$)",
            "productId": "int"
          }
        ]
      }
    ]
  }
```
but there was a following warning in logs (this is related with array nesting):
```21-02-16 22:38:26 WARNING (MainThread) [supervisor.store.data] Can't read /data/addons/git/d2d32cc6/cybele/config.json: expected string or buffer @ data['schema']['dongles'][0]['devices'][0]. Got {'type': 'str', 'friendlyName': 'str', 'mac': 'match(^([0-9A-F]{2}:){5}([0-9A-F]{2})$)', 'productId': 'int'}```
